### PR TITLE
Added support for multiple series in WithAutorange option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 junk
+
+# IDE files
+.idea

--- a/brackets/brackets.go
+++ b/brackets/brackets.go
@@ -124,6 +124,7 @@ func (b *Brackets) popElement() *Element {
 	return top.Value.(*Element)
 }
 
+// First returns the first element of the underlying list of elements.
 func (b *Brackets) First() *Element {
 	return b.elements.Front().Value.(*Element)
 }

--- a/brackets/brackets.go
+++ b/brackets/brackets.go
@@ -124,6 +124,10 @@ func (b *Brackets) popElement() *Element {
 	return top.Value.(*Element)
 }
 
+func (b *Brackets) First() *Element {
+	return b.elements.Front().Value.(*Element)
+}
+
 // Open adds a new opening element with optional attributes.
 func (b *Brackets) Open(name string, attrs ...Attributes) *Brackets {
 	if top := b.topElement(); top != nil {
@@ -165,7 +169,7 @@ func (b *Brackets) Text(txt string) *Brackets {
 
 // Close closes the current element. If there are no
 // children (elements or text), the current element will
-// be self-closed. Otherwise a matching close-element
+// be self-closed. Otherwise, a matching close-element
 // will be added.
 func (b *Brackets) Close() *Brackets {
 	top := b.popElement()

--- a/example/example.go
+++ b/example/example.go
@@ -16,7 +16,7 @@ func main() {
 	randomSeries := m.NewSeries()
 	rand.Seed(time.Now().Unix())
 	for i := float64(0); i < 10; i++ {
-		randomSeries.Add(m.MakeValue(i+1, 200*rand.Float64()))
+		randomSeries.Add(m.MakeValue(i+1, 1000*rand.Float64()))
 	}
 
 	testSeries := m.NewSeries()
@@ -29,7 +29,7 @@ func main() {
 
 	diagram := m.New(800, 600,
 		m.WithAutorange(m.XAxis, testSeries),
-		m.WithAutorange(m.YAxis, testSeries),
+		m.WithAutorange(m.YAxis, testSeries, randomSeries),
 		m.WithAutorange(m.Y2Axis, testSeries),
 		m.WithProjection(m.YAxis, m.Log),
 		m.WithInset(70),

--- a/margaid.go
+++ b/margaid.go
@@ -111,21 +111,32 @@ func WithRange(axis Axis, min, max float64) Option {
 	}
 }
 
-// WithAutorange sets range for an axis from the values of a series
-func WithAutorange(axis Axis, series *Series) Option {
+// WithAutorange sets range for an axis from the values of one or more series
+func WithAutorange(axis Axis, series ...*Series) Option {
 	return func(m *Margaid) {
 		var axisRange minmax
 
-		if axis == X1Axis || axis == X2Axis {
-			axisRange = minmax{
-				series.MinX(),
-				series.MaxX(),
+		for idx, s := range series {
+			var newAxisRange minmax
+			if axis == X1Axis || axis == X2Axis {
+				newAxisRange = minmax{
+					s.MinX(),
+					s.MaxX(),
+				}
 			}
-		}
-		if axis == Y1Axis || axis == Y2Axis {
-			axisRange = minmax{
-				series.MinY(),
-				series.MaxY(),
+			if axis == Y1Axis || axis == Y2Axis {
+				newAxisRange = minmax{
+					s.MinY(),
+					s.MaxY(),
+				}
+			}
+			if idx == 0 {
+				axisRange = newAxisRange
+			} else {
+				axisRange = minmax{
+					math.Min(axisRange.min, newAxisRange.min),
+					math.Max(axisRange.max, newAxisRange.max),
+				}
 			}
 		}
 

--- a/margaid.go
+++ b/margaid.go
@@ -222,7 +222,8 @@ const (
 	BottomLeft
 )
 
-// Legend draws a legend for named plots
+// Legend draws a legend for named plots. If position is set to BottomLeft, it
+// will grow the plot size to accommodate the number of legends displayed.
 func (m *Margaid) Legend(position LegendPosition) {
 	type namedPlot struct {
 		name  string
@@ -276,6 +277,11 @@ func (m *Margaid) Legend(position LegendPosition) {
 		m.g.Rect(xPos, yPos, boxSize, boxSize)
 		style("black")
 		m.g.Text(xPos+boxSize+textSpacing, yPos, brackets.XMLEscape(plot.name))
+	}
+
+	if position == BottomLeft {
+		newHeight := int(m.height + lineHeight*float64(len(plots)))
+		m.g.SetSize(int(m.width), newHeight)
 	}
 }
 

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -40,6 +40,13 @@ func New(width int, height int, background string) *SVG {
 	return &self
 }
 
+// SetSize of SVG, redefining the value given during construction.
+func (svg *SVG) SetSize(width, height int) {
+	elem := svg.brackets.First()
+	elem.SetAttribute("width", strconv.Itoa(width))
+	elem.SetAttribute("height", strconv.Itoa(height))
+}
+
 func (svg *SVG) addMarkers() {
 	svg.brackets.Open("defs").
 		Open("marker", br.Attributes{


### PR DESCRIPTION
hi @erkkah ,

I'm using Margaid often with multiple plots sharing the Y-axis, and I'm having to manually set the range to the max/min of all of them.

So I thought instead an idea would be to extend WithAutorange to support as input not only one series, but various.

It's a very simple changed, so I wrote the PR here directly -- it doesn't break compatibility with previous code (with maybe some very odd exception). 

Let me know if that works for you. If you prefer I could create also another type of option.

cheers

